### PR TITLE
support tinyint(1) as bool

### DIFF
--- a/ormtpl/00_struct.gogo
+++ b/ormtpl/00_struct.gogo
@@ -83,6 +83,22 @@ func (c *{{.GoName}}) Set{{.GoName}}(val []{{.GoType}}) {
 	}
 	c.val = strings.Join(strSlice, ",")
 }
+{{else if .IsBool}}
+type {{.GoName}} struct {
+	val int8
+}
+
+func (c *{{.GoName}}) Get{{.GoName}}() {{.GoType}} {
+	return c.val > 0
+}
+
+func (c *{{.GoName}}) Set{{.GoName}}(val {{.GoType}}) {
+	if val {
+		c.val = 1
+		return
+	}
+	c.val = 0
+}
 {{else}}
 type {{.GoName}} struct {
 	val {{.GoType}}


### PR DESCRIPTION
not testable with dolt db. 
when querying from **information_schema.columns**, FullDbType only returns tinyint instead of tinyint(1)

need to connect to mysql.
some problems encountered with connecting gola to mysql 5.7.32

1. show index from `table` only return 13 fields with mysql 5.7.32
2. Sub_part and Packed can be null and cannot be scanned in string. 
